### PR TITLE
TC-29#24: 평가 개수가 적은 영화 추천 안함

### DIFF
--- a/src/main/java/com/clipstory/clipstoryserver/controller/MovieSuggestionController.java
+++ b/src/main/java/com/clipstory/clipstoryserver/controller/MovieSuggestionController.java
@@ -1,11 +1,10 @@
 package com.clipstory.clipstoryserver.controller;
 
-import com.clipstory.clipstoryserver.domain.Movie;
 import com.clipstory.clipstoryserver.global.response.ApiResponse;
 import com.clipstory.clipstoryserver.global.response.Status;
 import com.clipstory.clipstoryserver.requestDto.MovieSuggestionRequestDto;
 import com.clipstory.clipstoryserver.responseDto.MovieResponseDto;
-import com.clipstory.clipstoryserver.responseDto.MovieSuggestionService;
+import com.clipstory.clipstoryserver.service.MovieSuggestionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/clipstory/clipstoryserver/repository/RatingRepository.java
+++ b/src/main/java/com/clipstory/clipstoryserver/repository/RatingRepository.java
@@ -9,4 +9,6 @@ public interface RatingRepository extends JpaRepository<Rating, Long> {
     @Query("SELECT AVG(r.score) FROM Rating r WHERE r.movie.id = :movieId")
     Double findAverageRatingByMovieId(Long movieId);
 
+    @Query("SELECT COUNT(r) FROM Rating r WHERE r.movie.id = :movieId")
+    Long countRatingByMovieId(Long movieId);
 }

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieService.java
@@ -7,13 +7,10 @@ import com.clipstory.clipstoryserver.global.response.GeneralException;
 import com.clipstory.clipstoryserver.global.response.Status;
 import com.clipstory.clipstoryserver.repository.MovieRepository;
 import com.clipstory.clipstoryserver.responseDto.MovieResponseDto;
-import com.clipstory.clipstoryserver.responseDto.MovieSuggestionService;
 import com.clipstory.clipstoryserver.responseDto.PagedResponseDto;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
-import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
@@ -1,8 +1,9 @@
-package com.clipstory.clipstoryserver.responseDto;
+package com.clipstory.clipstoryserver.service;
 
 import com.clipstory.clipstoryserver.domain.Movie;
 import com.clipstory.clipstoryserver.repository.MovieRepository;
 import com.clipstory.clipstoryserver.requestDto.MovieSuggestionRequestDto;
+import com.clipstory.clipstoryserver.responseDto.MovieResponseDto;
 import com.clipstory.clipstoryserver.service.MovieService;
 import com.clipstory.clipstoryserver.service.RatingService;
 import com.clipstory.clipstoryserver.service.TagService;
@@ -31,11 +32,11 @@ public class MovieSuggestionService {
 
     private static final int SUGGESTION_MOVIE_SIZE = 3;
 
-    private static final Double SIMILARITY_TO_PASS = 0.90;
-
     private static final Double GENRE_SIMILARITY_TO_PASS = 0.9;
 
     private static final Double TAG_SIMILARITY_TO_PASS = 0.0;
+
+    private static final Long COUNT_RATING_TO_PASS = 5L;
 
     public List<MovieResponseDto> getLikableMovies(MovieSuggestionRequestDto movieSuggestionRequestDto) {
         List<Movie> likeMovies = movieSuggestionRequestDto.getLikeMovieIdList()
@@ -76,15 +77,13 @@ public class MovieSuggestionService {
         for (Movie movie : movieService.findAllMovies()) {
             if (Objects.equals(movie.getId(), myMovie.getId())) {
                 continue;
+            } if (ratingService.countRatingByMovieId(movie.getId()) < COUNT_RATING_TO_PASS) {
+                continue;
+            } if (!isSimilarMovie(myMovie, movie)) {
+                continue;
             }
 
-            if (isSimilarMovie(myMovie, movie)) {
-                 /*log.info(myMovie.getTitle());
-                log.info(movie.getTitle());
-                log.info(similarity.toString());
-                log.info("");*/
-                similarMovies.add(movie);
-            }
+            similarMovies.add(movie);
         }
         return similarMovies;
     }

--- a/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
@@ -23,4 +23,8 @@ public class RatingService {
         return ratingRepository.findAverageRatingByMovieId(movieId);
     }
 
+    public Long countRatingByMovieId(Long movieId) {
+        return ratingRepository.countRatingByMovieId(movieId);
+    }
+
 }


### PR DESCRIPTION
평가수가 5개 미만인 영화는 추천하지 않도록 구현했습니다.
평가수를 세는 함수가 최적화되지 않아 속도가 느려 다음 태스크에서 최적화하도록 하겠습니다.

추가로 MovieSuggestionService 클래스가 ResponseDto에 있던 것을 발견하여, Service 쪽으로 옮겨주었습니다.
