### PR TITLE
TC-33#27: RatingService관련 Api 및 연산 최적화

### DIFF
--- a/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
@@ -32,7 +32,7 @@ public class Movie {
 
     private Double averageRating;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "id")
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "movie")
     @JsonBackReference
     public List<Rating> ratings;
 

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
@@ -1,27 +1,23 @@
 package com.clipstory.clipstoryserver.domain;
 
 import com.clipstory.clipstoryserver.service.GenreService;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.ManyToMany;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
 
 import java.sql.Wrapper;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import jakarta.persistence.Id;
+
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 @Builder
 @Getter
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Slf4j
 public class Movie {
 
     @Id
@@ -34,6 +30,12 @@ public class Movie {
     @ManyToMany
     private Set<Genre> genres;
 
+    private Double averageRating;
+
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "id")
+    @JsonBackReference
+    public List<Rating> ratings;
+
     public static Movie toEntity(Long id, Long tId, String title, Set<Genre> genres) {
         return Movie.builder()
                 .id(id)
@@ -41,6 +43,29 @@ public class Movie {
                 .title(title)
                 .genres(genres)
                 .build();
+    }
+
+    public void addRating(Rating rating) {
+        ratings.add(rating);
+    }
+
+    public void updateAverageRating(Double averageRating) {
+        this.averageRating = averageRating;
+    }
+
+    public void calculateAverageRating() {
+        Double averageRating = 0.0;
+        log.info(String.valueOf(ratings.size()));
+        for (Rating rating : ratings) {
+            log.info("평점 아이디 " + (rating.getId()));
+            averageRating += rating.getScore();
+        }
+
+        if (!ratings.isEmpty()) {
+            averageRating /= ratings.size();
+        }
+
+        updateAverageRating(averageRating);
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
@@ -29,7 +29,7 @@ public class Rating {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JsonManagedReference
+    @JoinColumn(name = "movie_id")
     private Movie movie;
 
     private Double score;

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
@@ -1,12 +1,9 @@
 package com.clipstory.clipstoryserver.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -31,8 +28,8 @@ public class Rating {
     @JsonBackReference
     private Member member;
 
-    @ManyToOne
-    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonManagedReference
     private Movie movie;
 
     private Double score;

--- a/src/main/java/com/clipstory/clipstoryserver/global/response/Status.java
+++ b/src/main/java/com/clipstory/clipstoryserver/global/response/Status.java
@@ -35,6 +35,9 @@ public enum Status {
 
     //TAG 오류 응답
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG404", "존재하지 않는 태그입니다."),
+
+    //Rating 오류 응답
+    RATING_NOT_FOUND(HttpStatus.NOT_FOUND, "RATING404", "존재하지 않는 평점입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
+++ b/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
@@ -31,6 +31,8 @@ public class MovieResponseDto {
 
     private Double averageRating;
 
+    private List<Long> ratingIdList;
+
     public static MovieResponseDto toMovieResponseDto(Movie movie, Double averageRating, List<Tag> tagList) {
         return MovieResponseDto.builder()
                 .id(movie.getId())
@@ -38,6 +40,7 @@ public class MovieResponseDto {
                 .tId(movie.getTId())
                 .genreNameList(movie.getGenres().stream().map(genre -> genre.getName()).collect(Collectors.toSet()))
                 .tagList(tagList.stream().map(tag -> tag.getContent()).collect(Collectors.toList()))
+                .ratingIdList(movie.getRatings().stream().map(rating -> rating.getId()).collect(Collectors.toList()))
                 .averageRating(averageRating)
                 .build();
     }

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieService.java
@@ -2,6 +2,7 @@ package com.clipstory.clipstoryserver.service;
 
 import com.clipstory.clipstoryserver.domain.Genre;
 import com.clipstory.clipstoryserver.domain.Movie;
+import com.clipstory.clipstoryserver.domain.Rating;
 import com.clipstory.clipstoryserver.domain.Tag;
 import com.clipstory.clipstoryserver.global.response.GeneralException;
 import com.clipstory.clipstoryserver.global.response.Status;
@@ -37,25 +38,29 @@ public class MovieService {
         movieRepository.save(movie);
     }
 
+    public void updateMovie(Movie movie) {
+        movieRepository.save(movie);
+    }
+
     public PagedResponseDto<MovieResponseDto> getMovies(Pageable pageable) {
         Page<Movie> movies = movieRepository.findAll(pageable);
         return new PagedResponseDto<>(movies.
                 map(movie ->  MovieResponseDto.toMovieResponseDto(
-                        movie, ratingService.getAverageRating(movie.getId()),
+                        movie, movie.getAverageRating(),
                         tagService.getTagsByMovieId(movie.getId()))));
     }
 
     public MovieResponseDto getMovie(Long movieId) {
         Movie movie = findMovieById(movieId);
         return MovieResponseDto.toMovieResponseDto(movie,
-                ratingService.getAverageRating(movieId), tagService.getTagsByMovieId(movie.getId()));
+                movie.getAverageRating(), tagService.getTagsByMovieId(movie.getId()));
     }
 
     public PagedResponseDto<MovieResponseDto> getMovieByPartOfTitle(String partOfTitle, Pageable pageable) {
         Page<Movie> movies = movieRepository.findByTitleContainingKeyword(partOfTitle, pageable);
         return new PagedResponseDto<>(movies.
                 map(movie ->  MovieResponseDto.toMovieResponseDto(
-                        movie, ratingService.getAverageRating(movie.getId()),
+                        movie, movie.getAverageRating(),
                         tagService.getTagsByMovieId(movie.getId()))));
     }
 
@@ -131,4 +136,12 @@ public class MovieService {
         movieVectors.get(movie.getId()).put(base, movieVector);
         return movieVector;
     }
+
+
+    public void calculateAverageRating(Movie movie) {
+
+
+    }
+
 }
+

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
@@ -53,14 +53,13 @@ public class MovieSuggestionService {
 
         return similarMovies.stream()
                 .map(movie -> MovieResponseDto.toMovieResponseDto(
-                        movie, ratingService.getAverageRating(movie.getId()), tagService.getTagsByMovieId(movie.getId())
+                        movie, movie.getAverageRating(), tagService.getTagsByMovieId(movie.getId())
                     )
                 )
                 .sorted(Comparator.comparingDouble(
-                            (MovieResponseDto movieResponseDto) -> movieResponseDto.getAverageRating() == null ? 0 : movieResponseDto.getAverageRating()
-                        ).reversed()
-                )
-                .toList().subList(0, SUGGESTION_MOVIE_SIZE);
+                        MovieResponseDto::getAverageRating
+                        ).reversed()).toList();
+                //.subList(0, SUGGESTION_MOVIE_SIZE);
     }
 
     public Set<Movie> getSimilarMovies(List<Movie> movies) {
@@ -77,9 +76,12 @@ public class MovieSuggestionService {
         for (Movie movie : movieService.findAllMovies()) {
             if (Objects.equals(movie.getId(), myMovie.getId())) {
                 continue;
-            } if (ratingService.countRatingByMovieId(movie.getId()) < COUNT_RATING_TO_PASS) {
+            }
+            log.info(String.valueOf(movie.getRatings().size()) );
+            if (movie.getRatings().size() < COUNT_RATING_TO_PASS) {
                 continue;
-            } if (!isSimilarMovie(myMovie, movie)) {
+            }
+            if (!isSimilarMovie(myMovie, movie)) {
                 continue;
             }
 
@@ -107,8 +109,8 @@ public class MovieSuggestionService {
         Double m1 = movieService.magnitude(movie1, base);
         Double m2 = movieService.magnitude(movie2, base);
 
-        Double result = (m1 == 0.0 || m2 == 0.0 ? 0.0 : (d / (m1 * m2)));
-        return result;
+        Double similarity = (m1 == 0.0 || m2 == 0.0 ? 0.0 : (d / (m1 * m2)));
+        return similarity;
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
@@ -58,8 +58,8 @@ public class MovieSuggestionService {
                 )
                 .sorted(Comparator.comparingDouble(
                         MovieResponseDto::getAverageRating
-                        ).reversed()).toList();
-                //.subList(0, SUGGESTION_MOVIE_SIZE);
+                        ).reversed()).toList()
+                .subList(0, Math.min(SUGGESTION_MOVIE_SIZE, similarMovies.size()));
     }
 
     public Set<Movie> getSimilarMovies(List<Movie> movies) {
@@ -77,7 +77,6 @@ public class MovieSuggestionService {
             if (Objects.equals(movie.getId(), myMovie.getId())) {
                 continue;
             }
-            log.info(String.valueOf(movie.getRatings().size()) );
             if (movie.getRatings().size() < COUNT_RATING_TO_PASS) {
                 continue;
             }

--- a/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
@@ -3,6 +3,8 @@ package com.clipstory.clipstoryserver.service;
 import com.clipstory.clipstoryserver.domain.Member;
 import com.clipstory.clipstoryserver.domain.Movie;
 import com.clipstory.clipstoryserver.domain.Rating;
+import com.clipstory.clipstoryserver.global.response.GeneralException;
+import com.clipstory.clipstoryserver.global.response.Status;
 import com.clipstory.clipstoryserver.repository.RatingRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -14,17 +16,18 @@ public class RatingService {
 
     private final RatingRepository ratingRepository;
 
-    public void createRating(Member member, Movie movie, Double score, LocalDateTime createdAt) {
+    public Rating createRating(Member member, Movie movie, Double score, LocalDateTime createdAt) {
         Rating rating = Rating.toEntity(member, movie, score, createdAt);
-        ratingRepository.save(rating);
+        return ratingRepository.save(rating);
     }
 
-    public Double getAverageRating(Long movieId) {
+    public Rating findRatingById(Long id) {
+        return ratingRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(Status.RATING_NOT_FOUND));
+    }
+
+    public Double getAverageRatingByMovieId(Long movieId) {
         return ratingRepository.findAverageRatingByMovieId(movieId);
-    }
-
-    public Long countRatingByMovieId(Long movieId) {
-        return ratingRepository.countRatingByMovieId(movieId);
     }
 
 }


### PR DESCRIPTION
영화 추천 속도 및 영화 API 속도를 최적화하였습니다.

Movie 클래스에 각 Movie에 대한 평균평점과 RatingList를 미리 계산합니다.
따라서 init 시에는 기존에 비해 추가적인 시간이 들지만, 서버가동 후 최초 추천시엔 4초, 그 이후론 1초 미만으로 나옵니다.

원래 계획엔 없던 버그 수정도 하나 했습니다.
추천될 수 있는 영화의 개수가 계획된 개수(=3)보다 작을 경우 에러가 발생하던 경우를 에러가 발생하지 않고, 적은 개수의 영화가 추천되도록 하였습니다. 따라서 최악의 경우 아무런 영화가 추천되지 않을 수 있습니다.