### PR TITLE
TC-24#26: 외부 api 호출 로직 추가, 데이터 적재 bulk 연산 로직 개발

### DIFF
--- a/src/main/java/com/clipstory/clipstoryserver/controller/InitController.java
+++ b/src/main/java/com/clipstory/clipstoryserver/controller/InitController.java
@@ -21,26 +21,10 @@ public class InitController {
 
     private final InitService initService;
 
-    @GetMapping("/movies")
-    @Operation(summary = "DB에 영화 데이터 적재")
-    public ApiResponse<?> addMovies() throws IOException {
-        initService.addMovies();
-        return ApiResponse.onSuccess(Status.OK.getCode(),
-                Status.CREATED.getMessage(), null);
-    }
-
-    @GetMapping("/tags")
-    @Operation(summary = "DB에 태그 데이터 적재")
-    public ApiResponse<?> addTags() throws IOException {
-        initService.addTags();
-        return ApiResponse.onSuccess(Status.OK.getCode(),
-                Status.CREATED.getMessage(), null);
-    }
-
-    @GetMapping("/ratings")
-    @Operation(summary = "DB에 평점 데이터 적재")
-    public ApiResponse<?> addRatings() throws IOException {
-        initService.addRatings();
+    @GetMapping("/")
+    @Operation(summary = "DB에 데이터 적재")
+    public ApiResponse<?> init() throws IOException {
+        initService.addData();
         return ApiResponse.onSuccess(Status.OK.getCode(),
                 Status.CREATED.getMessage(), null);
     }

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
@@ -1,9 +1,16 @@
 package com.clipstory.clipstoryserver.domain;
 
 import com.clipstory.clipstoryserver.service.GenreService;
+
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.ManyToMany;
+
 
 import java.sql.Wrapper;
 import java.util.*;
@@ -53,7 +60,7 @@ public class Movie {
         this.averageRating = averageRating;
     }
 
-    public void calculateAverageRating() {
+    public Movie calculateAverageRating() {
         Double averageRating = 0.0;
         log.info(String.valueOf(ratings.size()));
         for (Rating rating : ratings) {
@@ -66,6 +73,7 @@ public class Movie {
         }
 
         updateAverageRating(averageRating);
+        return this;
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
@@ -43,6 +43,10 @@ public class Movie {
     @JsonBackReference
     public List<Rating> ratings;
 
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "movie")
+    @JsonBackReference
+    public List<Tag> tags;
+
     public static Movie toEntity(Long id, Long tId, String title, Set<Genre> genres) {
         return Movie.builder()
                 .id(id)
@@ -54,6 +58,10 @@ public class Movie {
 
     public void addRating(Rating rating) {
         ratings.add(rating);
+    }
+
+    public void addTag(Tag tag) {
+        tags.add(tag);
     }
 
     public void updateAverageRating(Double averageRating) {

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Movie.java
@@ -62,9 +62,7 @@ public class Movie {
 
     public Movie calculateAverageRating() {
         Double averageRating = 0.0;
-        log.info(String.valueOf(ratings.size()));
         for (Rating rating : ratings) {
-            log.info("평점 아이디 " + (rating.getId()));
             averageRating += rating.getScore();
         }
 

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Rating.java
@@ -34,7 +34,6 @@ public class Rating {
 
     private Double score;
 
-    @CreatedDate
     private LocalDateTime createdAt;
 
     public static Rating toEntity(Member member, Movie movie, Double score, LocalDateTime createdAt) {

--- a/src/main/java/com/clipstory/clipstoryserver/domain/Tag.java
+++ b/src/main/java/com/clipstory/clipstoryserver/domain/Tag.java
@@ -2,9 +2,11 @@ package com.clipstory.clipstoryserver.domain;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
@@ -31,7 +33,8 @@ public class Tag {
     @ManyToOne
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "movie_id")
     private Movie movie;
 
     private String content;

--- a/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
+++ b/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
@@ -3,6 +3,7 @@ package com.clipstory.clipstoryserver.repository;
 import com.clipstory.clipstoryserver.domain.Genre;
 import com.clipstory.clipstoryserver.domain.Movie;
 import com.clipstory.clipstoryserver.domain.Rating;
+import com.clipstory.clipstoryserver.service.InitService;
 import jakarta.transaction.Transactional;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -54,8 +55,7 @@ public class BulkRepository {
     }
 
     @Transactional
-    public void asdf (List<Movie> movieList) {
-
+    public void saveAllMovieGenres (List<InitService.MovieGenre> movieGenreList) {
 
         String insertMovieGenreSQL = "INSERT INTO movie_genres (genres_id, movie_id)" +
                 "VALUES (?, ?)";
@@ -63,36 +63,17 @@ public class BulkRepository {
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
-                        Movie movie = movieList.get(i);
-                        Long movieId = movie.getId();
-                        Set<Genre> genres = movie.getGenres();
+                        InitService.MovieGenre movieGenre = movieGenreList.get(i);
+                        Long movieId = movieGenre.movieId;
+                        Long genreId = movieGenre.genreId;
 
-                 /*       int size = 0;
-                        for(Movie m : movieList) {
-                            size += m.getGenres().size();
-                        }
-                        log.info(String.valueOf(size));
-*/
-                        Iterator<Genre> iterSet = genres.iterator();
-                        while(iterSet.hasNext()) {
-                            Genre g = iterSet.next();
-                            ps.setLong(1, g.getId());
-                            ps.setLong(2, movieId);
-
-                            log.info(movieId + " " + g.getName());
-                        }
-                        //ps.addBatch();
-/*
-                        ps.execute();
-                        log.info("실행함");
-                        ps.clearBatch();
-                        log.info("지움");*/
-
+                        ps.setLong(1, genreId);
+                        ps.setLong(2, movieId);
                     }
 
                     @Override
                     public int getBatchSize() {
-                        return movieList.size();
+                        return movieGenreList.size();
                     }
                 });
     }

--- a/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
+++ b/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
@@ -3,6 +3,7 @@ package com.clipstory.clipstoryserver.repository;
 import com.clipstory.clipstoryserver.domain.Genre;
 import com.clipstory.clipstoryserver.domain.Movie;
 import com.clipstory.clipstoryserver.domain.Rating;
+import com.clipstory.clipstoryserver.domain.Tag;
 import com.clipstory.clipstoryserver.service.InitService;
 import jakarta.transaction.Transactional;
 import java.sql.PreparedStatement;
@@ -48,10 +49,6 @@ public class BulkRepository {
                         return movieList.size();
                     }
                 });
-
-       // asdf(movieList);
-
-
     }
 
     @Transactional
@@ -119,6 +116,30 @@ public class BulkRepository {
                         return movieList.size();
                     }
                 });
+    }
+
+    @Transactional
+    public void saveAllTags(List<Tag> tagList) {
+        String sql = "INSERT INTO tag (content, member_id, movie_id, created_at)" +
+                "VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Tag tag = tagList.get(i);
+                        ps.setString(1, tag.getContent());
+                        ps.setLong(2, tag.getMember().getId());
+                        ps.setLong(3, tag.getMovie().getId());
+                        ps.setObject(4, tag.getCreatedAt());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return tagList.size();
+                    }
+                });
+
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
+++ b/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
@@ -1,0 +1,143 @@
+package com.clipstory.clipstoryserver.repository;
+
+import com.clipstory.clipstoryserver.domain.Genre;
+import com.clipstory.clipstoryserver.domain.Movie;
+import com.clipstory.clipstoryserver.domain.Rating;
+import jakarta.transaction.Transactional;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BulkRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAllMovies(List<Movie> movieList) {
+        String insertMovieSQL = "INSERT INTO movie (id, title, t_id)" +
+                "VALUES (?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(insertMovieSQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Movie movie = movieList.get(i);
+                        ps.setLong(1, movie.getId());
+                        ps.setString(2, movie.getTitle());
+                        if (movie.getTId() != null) {
+                            ps.setLong(3, movie.getTId());
+                        } else {
+                            ps.setNull(3, Types.BIGINT);
+                        }
+
+                    }
+                    @Override
+                    public int getBatchSize() {
+                        return movieList.size();
+                    }
+                });
+
+       // asdf(movieList);
+
+
+    }
+
+    @Transactional
+    public void asdf (List<Movie> movieList) {
+
+
+        String insertMovieGenreSQL = "INSERT INTO movie_genres (genres_id, movie_id)" +
+                "VALUES (?, ?)";
+        jdbcTemplate.batchUpdate(insertMovieGenreSQL,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Movie movie = movieList.get(i);
+                        Long movieId = movie.getId();
+                        Set<Genre> genres = movie.getGenres();
+
+                 /*       int size = 0;
+                        for(Movie m : movieList) {
+                            size += m.getGenres().size();
+                        }
+                        log.info(String.valueOf(size));
+*/
+                        Iterator<Genre> iterSet = genres.iterator();
+                        while(iterSet.hasNext()) {
+                            Genre g = iterSet.next();
+                            ps.setLong(1, g.getId());
+                            ps.setLong(2, movieId);
+
+                            log.info(movieId + " " + g.getName());
+                        }
+                        //ps.addBatch();
+/*
+                        ps.execute();
+                        log.info("실행함");
+                        ps.clearBatch();
+                        log.info("지움");*/
+
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return movieList.size();
+                    }
+                });
+    }
+
+    @Transactional
+    public void saveAllRatings(List<Rating> ratingList) {
+        String sql = "INSERT INTO rating (member_id, movie_id, score, created_at)" +
+                "VALUES (?, ?, ?, ?)";
+
+        jdbcTemplate.batchUpdate(sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Rating rating = ratingList.get(i);
+                        ps.setLong(1, rating.getMember().getId());
+                        ps.setLong(2, rating.getMovie().getId());
+                        ps.setDouble(3, rating.getScore());
+                        ps.setObject(4, rating.getCreatedAt());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return ratingList.size();
+                    }
+                });
+    }
+
+    @Transactional
+    public void saveAllAverageRatingRatings(List<Movie> movieList) {
+        String sql = "UPDATE table_name SET average_rating = ?, WHERE id = ?";
+
+        jdbcTemplate.batchUpdate(sql,
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Movie movie = movieList.get(i);
+                        ps.setDouble(1, movie.getAverageRating());
+                        ps.setLong(2, movie.getId());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return movieList.size();
+                    }
+                });
+    }
+
+}

--- a/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
+++ b/src/main/java/com/clipstory/clipstoryserver/repository/BulkRepository.java
@@ -103,7 +103,7 @@ public class BulkRepository {
 
     @Transactional
     public void saveAllAverageRatingRatings(List<Movie> movieList) {
-        String sql = "UPDATE table_name SET average_rating = ?, WHERE id = ?";
+        String sql = "UPDATE movie SET average_rating = ? WHERE id = ?";
 
         jdbcTemplate.batchUpdate(sql,
                 new BatchPreparedStatementSetter() {

--- a/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieExtraInformationResponseDto.java
+++ b/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieExtraInformationResponseDto.java
@@ -1,0 +1,22 @@
+package com.clipstory.clipstoryserver.responseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class MovieExtraInformationResponseDto {
+
+    private String poster_path;
+
+    private boolean adult;
+
+    private String overview;
+
+}

--- a/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
+++ b/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
@@ -31,8 +31,6 @@ public class MovieResponseDto {
 
     private Double averageRating;
 
-    private List<Long> ratingIdList;
-
     private String imageUrl;
 
     private Boolean isAdult;
@@ -47,7 +45,6 @@ public class MovieResponseDto {
                 .tId(movie.getTId())
                 .genreNameList(movie.getGenres().stream().map(genre -> genre.getName()).collect(Collectors.toSet()))
                 .tagList(tagList.stream().map(tag -> tag.getContent()).collect(Collectors.toList()))
-                .ratingIdList(movie.getRatings().stream().map(rating -> rating.getId()).collect(Collectors.toList()))
                 .averageRating(averageRating)
                 .imageUrl(movieExtraInformationResponseDto.getPoster_path())
                 .isAdult(movieExtraInformationResponseDto.isAdult())

--- a/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
+++ b/src/main/java/com/clipstory/clipstoryserver/responseDto/MovieResponseDto.java
@@ -33,7 +33,14 @@ public class MovieResponseDto {
 
     private List<Long> ratingIdList;
 
-    public static MovieResponseDto toMovieResponseDto(Movie movie, Double averageRating, List<Tag> tagList) {
+    private String imageUrl;
+
+    private Boolean isAdult;
+
+    private String overView;
+
+    public static MovieResponseDto toMovieResponseDto(Movie movie, Double averageRating, List<Tag> tagList, MovieExtraInformationResponseDto movieExtraInformationResponseDto) {
+
         return MovieResponseDto.builder()
                 .id(movie.getId())
                 .title(movie.getTitle())
@@ -42,7 +49,11 @@ public class MovieResponseDto {
                 .tagList(tagList.stream().map(tag -> tag.getContent()).collect(Collectors.toList()))
                 .ratingIdList(movie.getRatings().stream().map(rating -> rating.getId()).collect(Collectors.toList()))
                 .averageRating(averageRating)
+                .imageUrl(movieExtraInformationResponseDto.getPoster_path())
+                .isAdult(movieExtraInformationResponseDto.isAdult())
+                .overView(movieExtraInformationResponseDto.getOverview())
                 .build();
+
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
@@ -45,17 +45,10 @@ public class InitService {
 
     private final BulkRepository bulkRepository;
 
-    public class MovieGenre {
-
-        public Long movieId;
-
-        public Long genreId;
-
-        MovieGenre(Long movieId, Long genreId) {
-            this.movieId = movieId;
-            this.genreId = genreId;
-        }
-
+    public void addData() throws IOException {
+        addMovies();
+        addRatings();
+        addTags();
     }
 
     public void addMovies() throws IOException {
@@ -71,9 +64,9 @@ public class InitService {
 
         String line = null;
         br.readLine();
-
         List<Movie> movieList = new ArrayList<>();
         List<MovieGenre> movieGenreList = new ArrayList<>();
+
         while ((line = br.readLine()) != null) {
             if (movieList.size() >= 100) {
                 bulkRepository.saveAllMovies(movieList);
@@ -81,11 +74,12 @@ public class InitService {
                 movieList.clear();
                 movieGenreList.clear();
             }
+
             String[] token = line.split(",");
             Long movieId = Long.parseLong(token[0]);
             String[] genre = token[token.length - 1].split("\\|");
-
             StringBuilder titleBuilder = new StringBuilder();
+
             for(int i = 1; i < token.length - 1; i++) {
                 titleBuilder.append(token[i]);
                 if(i != token.length-2) titleBuilder.append(",");
@@ -131,6 +125,7 @@ public class InitService {
                 bulkRepository.saveAllTags(tagList);
                 tagList.clear();
             }
+
             String[] token = line.split(",");
             String memberCustomId = token[0];
             Long movieId = Long.parseLong(token[1]);
@@ -155,7 +150,7 @@ public class InitService {
     }
 
     public void addRatings() throws IOException {
-        ClassPathResource resource = new ClassPathResource("static/ratings0.csv");
+        ClassPathResource resource = new ClassPathResource("static/ratings.csv");
         File moviesCsv = resource.getFile();
 
         BufferedReader br = null;
@@ -176,8 +171,6 @@ public class InitService {
             String[] token = line.split(",");
             String memberCustomId = token[0];
             Long movieId = Long.parseLong(token[1]);
-           /* log.info("movieId" + movieId);
-            log.info("memberCustomId" + memberCustomId);*/
             Double score = Double.parseDouble(token[2]);
             Long timeStamp = Long.parseLong(token[3]);
             Instant instant = Instant.ofEpochSecond(timeStamp);
@@ -207,6 +200,19 @@ public class InitService {
             movieList.add(updatedMovie);
         }
         bulkRepository.saveAllAverageRatingRatings(movieList);
+    }
+
+    public class MovieGenre {
+
+        public Long movieId;
+
+        public Long genreId;
+
+        MovieGenre(Long movieId, Long genreId) {
+            this.movieId = movieId;
+            this.genreId = genreId;
+        }
+
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,19 @@ public class InitService {
 
     private final BulkRepository bulkRepository;
 
+    public class MovieGenre {
+
+        public Long movieId;
+
+        public Long genreId;
+
+        MovieGenre(Long movieId, Long genreId) {
+            this.movieId = movieId;
+            this.genreId = genreId;
+        }
+
+    }
+
     public void addMovies() throws IOException {
         ClassPathResource resource = new ClassPathResource("static/movies.csv");
         File moviesCsv = resource.getFile();
@@ -58,11 +72,13 @@ public class InitService {
         br.readLine();
 
         List<Movie> movieList = new ArrayList<>();
+        List<MovieGenre> movieGenreList = new ArrayList<>();
         while ((line = br.readLine()) != null) {
             if (movieList.size() >= 100) {
                 bulkRepository.saveAllMovies(movieList);
-                bulkRepository.asdf(movieList);
+                bulkRepository.saveAllMovieGenres(movieGenreList);
                 movieList.clear();
+                movieGenreList.clear();
             }
             String[] token = line.split(",");
             Long movieId = Long.parseLong(token[0]);
@@ -81,10 +97,18 @@ public class InitService {
                     .collect(Collectors.toSet());
 
             Movie movie = movieService.createMovie(movieId, tId, title, genres);
+
+            Iterator<Genre> iterSet = genres.iterator();
+            while(iterSet.hasNext()) {
+                Genre g = iterSet.next();
+                MovieGenre movieGenre = new MovieGenre(movieId, g.getId());
+                movieGenreList.add(movieGenre);
+            }
+
             movieList.add(movie);
         }
         bulkRepository.saveAllMovies(movieList);
-        bulkRepository.asdf(movieList);
+        bulkRepository.saveAllMovieGenres(movieGenreList);
     }
 
     public void addTags() throws IOException {

--- a/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/InitService.java
@@ -138,14 +138,12 @@ public class InitService {
             Member member = memberService.findMemberByCustomId(memberCustomId);
             Movie movie = null;
             movie = movieService.findMovieById(movieId);
-
-
             tagService.createTag(member, movie, tagContent, createdAt);
         }
     }
 
     public void addRatings() throws IOException {
-        ClassPathResource resource = new ClassPathResource("static/ratings.csv");
+        ClassPathResource resource = new ClassPathResource("static/ratings0.csv");
         File moviesCsv = resource.getFile();
 
         BufferedReader br = null;
@@ -178,9 +176,14 @@ public class InitService {
 
             Rating rating =  ratingService.createRating(member, movie, score, createdAt);
             ratingList.add(rating);
-            //movie.addRating(rating);
+
         }
         bulkRepository.saveAllRatings(ratingList);
+
+        for (Rating rating : ratingService.getAllRatings()) {
+            Movie movie = rating.getMovie();
+            movie.addRating(rating);
+        }
 
         List<Movie> movieList = new ArrayList<>();
         for (Movie movie : movieService.findAllMovies()) {

--- a/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/MovieSuggestionService.java
@@ -52,10 +52,12 @@ public class MovieSuggestionService {
         similarMovies.removeAll(getSimilarMovies(hateMovies));
 
         return similarMovies.stream()
-                .map(movie -> MovieResponseDto.toMovieResponseDto(
-                        movie, movie.getAverageRating(), tagService.getTagsByMovieId(movie.getId())
+                .map(movie ->
+                        MovieResponseDto.toMovieResponseDto(
+                                movie, movie.getAverageRating(),
+                                tagService.getTagsByMovieId(movie.getId()),
+                                movieService.addMovieInformation(movie))
                     )
-                )
                 .sorted(Comparator.comparingDouble(
                         MovieResponseDto::getAverageRating
                         ).reversed()).toList()

--- a/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
@@ -17,8 +17,7 @@ public class RatingService {
     private final RatingRepository ratingRepository;
 
     public Rating createRating(Member member, Movie movie, Double score, LocalDateTime createdAt) {
-        Rating rating = Rating.toEntity(member, movie, score, createdAt);
-        return ratingRepository.save(rating);
+        return Rating.toEntity(member, movie, score, createdAt);
     }
 
     public Rating findRatingById(Long id) {

--- a/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/RatingService.java
@@ -7,6 +7,7 @@ import com.clipstory.clipstoryserver.global.response.GeneralException;
 import com.clipstory.clipstoryserver.global.response.Status;
 import com.clipstory.clipstoryserver.repository.RatingRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,10 @@ public class RatingService {
 
     public Double getAverageRatingByMovieId(Long movieId) {
         return ratingRepository.findAverageRatingByMovieId(movieId);
+    }
+
+    public List<Rating> getAllRatings() {
+        return ratingRepository.findAll();
     }
 
 }

--- a/src/main/java/com/clipstory/clipstoryserver/service/TagService.java
+++ b/src/main/java/com/clipstory/clipstoryserver/service/TagService.java
@@ -21,9 +21,8 @@ public class TagService {
 
     private final TagRepository tagRepository;
 
-    public void createTag(Member member, Movie movie, String content, LocalDateTime createdAt) {
-        Tag tag = Tag.toEntity(member, movie, content, createdAt);
-        tagRepository.save(tag);
+    public Tag createTag(Member member, Movie movie, String content, LocalDateTime createdAt) {
+        return Tag.toEntity(member, movie, content, createdAt);
     }
 
     public TagResponseDto getTag(Long tagId) {
@@ -39,6 +38,10 @@ public class TagService {
     public PagedResponseDto<TagResponseDto> getAllTag(Pageable pageable) {
         Page<Tag> tags = tagRepository.findAll(pageable);
         return new PagedResponseDto<>(tags.map(tag -> TagResponseDto.toResponseDto(tag)));
+    }
+
+    public List<Tag> getAllTag() {
+        return tagRepository.findAll();
     }
 
     public List<Tag> getTagsByMovieId(Long movieId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,6 @@ jwt:
   token-prefix: ${JWT_TOKEN_PREFIX}
   access-token-duration: ${JWT_ACCESS_TOKEN_DURATION}
   refresh-token-duration: ${JWT_REFRESH_TOKEN_DURATION}
+
+tmdb:
+  api_key: ${TMDB_KEY}

--- a/src/main/resources/static/movies0.csv
+++ b/src/main/resources/static/movies0.csv
@@ -1,0 +1,100 @@
+movieId,title,genres
+1,Toy Story (1995),Adventure|Animation|Children|Comedy|Fantasy
+2,Jumanji (1995),Adventure|Children|Fantasy
+3,Grumpier Old Men (1995),Comedy|Romance
+4,Waiting to Exhale (1995),Comedy|Drama|Romance
+5,Father of the Bride Part II (1995),Comedy
+6,Heat (1995),Action|Crime|Thriller
+7,Sabrina (1995),Comedy|Romance
+8,Tom and Huck (1995),Adventure|Children
+9,Sudden Death (1995),Action
+10,GoldenEye (1995),Action|Adventure|Thriller
+11,"American President, The (1995)",Comedy|Drama|Romance
+12,Dracula: Dead and Loving It (1995),Comedy|Horror
+13,Balto (1995),Adventure|Animation|Children
+14,Nixon (1995),Drama
+15,Cutthroat Island (1995),Action|Adventure|Romance
+16,Casino (1995),Crime|Drama
+17,Sense and Sensibility (1995),Drama|Romance
+18,Four Rooms (1995),Comedy
+19,Ace Ventura: When Nature Calls (1995),Comedy
+20,Money Train (1995),Action|Comedy|Crime|Drama|Thriller
+21,Get Shorty (1995),Comedy|Crime|Thriller
+22,Copycat (1995),Crime|Drama|Horror|Mystery|Thriller
+23,Assassins (1995),Action|Crime|Thriller
+24,Powder (1995),Drama|Sci-Fi
+25,Leaving Las Vegas (1995),Drama|Romance
+26,Othello (1995),Drama
+27,Now and Then (1995),Children|Drama
+28,Persuasion (1995),Drama|Romance
+29,"City of Lost Children, The (Cité des enfants perdus, La) (1995)",Adventure|Drama|Fantasy|Mystery|Sci-Fi
+30,Shanghai Triad (Yao a yao yao dao waipo qiao) (1995),Crime|Drama
+31,Dangerous Minds (1995),Drama
+32,Twelve Monkeys (a.k.a. 12 Monkeys) (1995),Mystery|Sci-Fi|Thriller
+34,Babe (1995),Children|Drama
+36,Dead Man Walking (1995),Crime|Drama
+38,It Takes Two (1995),Children|Comedy
+39,Clueless (1995),Comedy|Romance
+40,"Cry, the Beloved Country (1995)",Drama
+41,Richard III (1995),Drama|War
+42,Dead Presidents (1995),Action|Crime|Drama
+43,Restoration (1995),Drama
+44,Mortal Kombat (1995),Action|Adventure|Fantasy
+45,To Die For (1995),Comedy|Drama|Thriller
+46,How to Make an American Quilt (1995),Drama|Romance
+47,Seven (a.k.a. Se7en) (1995),Mystery|Thriller
+48,Pocahontas (1995),Animation|Children|Drama|Musical|Romance
+49,When Night Is Falling (1995),Drama|Romance
+50,"Usual Suspects, The (1995)",Crime|Mystery|Thriller
+52,Mighty Aphrodite (1995),Comedy|Drama|Romance
+53,Lamerica (1994),Adventure|Drama
+54,"Big Green, The (1995)",Children|Comedy
+55,Georgia (1995),Drama
+57,Home for the Holidays (1995),Drama
+58,"Postman, The (Postino, Il) (1994)",Comedy|Drama|Romance
+60,"Indian in the Cupboard, The (1995)",Adventure|Children|Fantasy
+61,Eye for an Eye (1996),Drama|Thriller
+62,Mr. Holland's Opus (1995),Drama
+63,Don't Be a Menace to South Central While Drinking Your Juice in the Hood (1996),Comedy|Crime
+64,Two if by Sea (1996),Comedy|Romance
+65,Bio-Dome (1996),Comedy
+66,Lawnmower Man 2: Beyond Cyberspace (1996),Action|Sci-Fi|Thriller
+68,French Twist (Gazon maudit) (1995),Comedy|Romance
+69,Friday (1995),Comedy
+70,From Dusk Till Dawn (1996),Action|Comedy|Horror|Thriller
+71,Fair Game (1995),Action
+72,Kicking and Screaming (1995),Comedy|Drama
+73,"Misérables, Les (1995)",Drama|War
+74,Bed of Roses (1996),Drama|Romance
+75,Big Bully (1996),Comedy|Drama
+76,Screamers (1995),Action|Sci-Fi|Thriller
+77,Nico Icon (1995),Documentary
+78,"Crossing Guard, The (1995)",Action|Crime|Drama|Thriller
+79,"Juror, The (1996)",Drama|Thriller
+80,"White Balloon, The (Badkonake sefid) (1995)",Children|Drama
+81,Things to Do in Denver When You're Dead (1995),Crime|Drama|Romance
+82,Antonia's Line (Antonia) (1995),Comedy|Drama
+83,Once Upon a Time... When We Were Colored (1995),Drama|Romance
+85,Angels and Insects (1995),Drama|Romance
+86,White Squall (1996),Action|Adventure|Drama
+87,Dunston Checks In (1996),Children|Comedy
+88,Black Sheep (1996),Comedy
+89,Nick of Time (1995),Action|Thriller
+92,Mary Reilly (1996),Drama|Horror|Thriller
+93,Vampire in Brooklyn (1995),Comedy|Horror|Romance
+94,Beautiful Girls (1996),Comedy|Drama|Romance
+95,Broken Arrow (1996),Action|Adventure|Thriller
+96,In the Bleak Midwinter (1995),Comedy|Drama
+97,"Hate (Haine, La) (1995)",Crime|Drama
+99,Heidi Fleiss: Hollywood Madam (1995),Documentary
+100,City Hall (1996),Drama|Thriller
+101,Bottle Rocket (1996),Adventure|Comedy|Crime|Romance
+102,Mr. Wrong (1996),Comedy
+103,Unforgettable (1996),Mystery|Sci-Fi|Thriller
+104,Happy Gilmore (1996),Comedy
+105,"Bridges of Madison County, The (1995)",Drama|Romance
+106,Nobody Loves Me (Keiner liebt mich) (1994),Comedy|Drama
+107,Muppet Treasure Island (1996),Adventure|Children|Comedy|Musical
+108,Catwalk (1996),Documentary
+110,Braveheart (1995),Action|Drama|War
+111,Taxi Driver (1976),Crime|Drama|Thriller


### PR DESCRIPTION
1. tmdb의 api 호출로 영화 포스터 이미지, 영화 줄거리 설명, isAdult 정보를 가져옵니다.

다만 isAdult 정보가 정확하지 않은 것 같아서 우리의 userStory의 영화에 포함된 민감한 정보를
잘 표현할 수 있을지 고민입니다..

2. 그리고 여태까지 백엔드 DB에서 칼럼 수정할 때마다 계속 table을 drop 하고 다시 적재하는데
너무 오래걸려서 거의 2~3시간이 걸렸습니다.

이를 보완하고자 bulk 연산 사용해서 지금 모든 데이터 적재사는데 7분 정도 걸리도록 수정했습니다.

아래 사진 첨부합니다.
<img width="1278" alt="image" src="https://github.com/Dev-Kkoddorong/ClipStory-server/assets/96719969/45e14b99-a31b-4e9b-a0c0-a0adff5b1178">

<img width="1278" alt="image" src="https://github.com/Dev-Kkoddorong/ClipStory-server/assets/96719969/d5dc5acd-da26-4266-b135-0db1c20c7408">

<img width="1278" alt="image" src="https://github.com/Dev-Kkoddorong/ClipStory-server/assets/96719969/cfafcfee-e752-4d9c-b1c9-bc2644c87c97">
